### PR TITLE
post-command: Fix keyless signing.

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -58,7 +58,7 @@ cosign_keyless() {
 
     rm out.sig || true
 
-    COSIGN EXPERIMENTAL=1 cosign sign \
+    COSIGN_EXPERIMENTAL=1 cosign sign \
         -y \
         --fulcio-url="${fulcio_url}" \
         --rekor-url="${rekor_url}" \
@@ -66,7 +66,7 @@ cosign_keyless() {
         --oidc-provider="${oidc_provider}" \
         --output-signature=out.sig \
         "${image}"
-    
+
     status=$?
     if [[ $status -ne 0 ]]; then
         fail_with_message "cosign" "Failed to sign image"


### PR DESCRIPTION
The keyless signing feature (used to) rely on the COSIGN_EXPERIMENTAL environment variable being set to "1". The post-command shell script attempts to set this environment variable when executing cosign if the user specifies keyless signing.

The environment variable name was missing the underscore character. This caused keyless signing attempts to fail because the shell would interpret "COSIGN" as a shell command. [1]

This commit also removes some extra empty space.

References

1. https://buildkite.com/metal-toolbox/governor-slack-addon/builds/106#018c122e-21ab-4488-b03a-0c5131595448