### PR TITLE
keyless: Disable by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ References the image to sign
 ### `keyless` (Optional, boolean)
 
 If set to `true`, the plugin will use keyless signatures. If set to `false`, the
-plugin will use a keypair. If not specified, the plugin will default to `true`.
+plugin will use a keypair. If not specified, the plugin will default to `false`
+to avoid accidentally exposing information to the public Sigstore infrastructure.
 
 ### `keyless-config` (Optional, object)
 

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -43,7 +43,7 @@ if [[ -z "${image}" ]]; then
     fail_with_message "cosign" "No image specified"
 fi
 
-is_keyless=${BUILDKITE_PLUGIN_COSIGN_KEYLESS:-true}
+is_keyless=${BUILDKITE_PLUGIN_COSIGN_KEYLESS:-false}
 
 # Hook functions
 ################

--- a/plugin.yml
+++ b/plugin.yml
@@ -14,7 +14,7 @@ configuration:
     keyless: 
       type: boolean
       description: "Use keyless signing"
-      default: true
+      default: false
     keyless-config:
       type: object
       properties:


### PR DESCRIPTION
Keyless signing exposes information to the Chainguard-hosted Sigstore infrastructure. The previous default behavior made it possible to accidentally sign an artifact using the public Sigstore infrastructure.

Now, users must explicitly opt-in to keyless signing. This also protects against misconfigured CI systems that would ordinarily use a private Sigstore instance for keyless signing.