### PR TITLE
Set Metadata for Image Tag

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -209,3 +209,5 @@ else
 fi
 
 cosign_sign
+
+buildkite-agent meta-data set "image-sha" $image


### PR DESCRIPTION
uploads the signed image sha as metadata to obtain in later steps.
